### PR TITLE
Fix: add Coveralls' missing javax/xml/bind/DatatypeConverter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
 				<groupId>org.eluder.coveralls</groupId>
 				<artifactId>coveralls-maven-plugin</artifactId>
 				<version>4.3.0</version>
+				<dependencies>
+					<dependency>
+						<groupId>javax.xml.bind</groupId>
+						<artifactId>jaxb-api</artifactId>
+						<version>2.2.4</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
... as otherwise, Java 9+ builds are failing with:

```
[ERROR] Failed to execute goal org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report (default-cli) on project algo-exercises: Execution default-cli of goal org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report failed: A required class was missing while executing org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report: javax/xml/bind/DatatypeConverter
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.eluder.coveralls:coveralls-maven-plugin:4.3.0
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/travis/.m2/repository/org/eluder/coveralls/coveralls-maven-plugin/4.3.0/coveralls-maven-plugin-4.3.0.jar
[ERROR] urls[1] = file:/home/travis/.m2/repository/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.jar
[ERROR] urls[2] = file:/home/travis/.m2/repository/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar
[ERROR] urls[3] = file:/home/travis/.m2/repository/commons-codec/commons-codec/1.9/commons-codec-1.9.jar
[ERROR] urls[4] = file:/home/travis/.m2/repository/org/apache/httpcomponents/httpmime/4.5.2/httpmime-4.5.2.jar
[ERROR] urls[5] = file:/home/travis/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.8.3/jackson-core-2.8.3.jar
[ERROR] urls[6] = file:/home/travis/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.8.3/jackson-annotations-2.8.3.jar
[ERROR] urls[7] = file:/home/travis/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.8.3/jackson-databind-2.8.3.jar
[ERROR] urls[8] = file:/home/travis/.m2/repository/org/eclipse/jgit/org.eclipse.jgit/4.5.0.201609210915-r/org.eclipse.jgit-4.5.0.201609210915-r.jar
[ERROR] urls[9] = file:/home/travis/.m2/repository/com/jcraft/jsch/0.1.53/jsch-0.1.53.jar
[ERROR] urls[10] = file:/home/travis/.m2/repository/com/googlecode/javaewah/JavaEWAH/0.7.9/JavaEWAH-0.7.9.jar
[ERROR] urls[11] = file:/home/travis/.m2/repository/org/codehaus/plexus/plexus-utils/2.0.7/plexus-utils-2.0.7.jar
[ERROR] urls[12] = file:/home/travis/.m2/repository/org/sonatype/sisu/sisu-inject-bean/1.4.3.2/sisu-inject-bean-1.4.3.2.jar
[ERROR] urls[13] = file:/home/travis/.m2/repository/org/sonatype/sisu/sisu-guice/2.9.2/sisu-guice-2.9.2-no_aop.jar
[ERROR] urls[14] = file:/home/travis/.m2/repository/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar
[ERROR] urls[15] = file:/home/travis/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar
[ERROR] urls[16] = file:/home/travis/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
[ERROR] urls[17] = file:/home/travis/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[18] = file:/home/travis/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[19] = file:/home/travis/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.21/jcl-over-slf4j-1.7.21.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR]
[ERROR] -----------------------------------------------------
[ERROR] : javax.xml.bind.DatatypeConverter
```

See also:
- https://github.com/trautonen/coveralls-maven-plugin/issues/112
- https://travis-ci.org/github/marccarre/algo-exercises/jobs/753735230
- https://travis-ci.org/github/marccarre/algo-exercises/jobs/753735231